### PR TITLE
Added missing translation for SLOW_FALLING

### DIFF
--- a/src/dev/_2lstudios/viarewindpotions/utils/PotionTranslator.java
+++ b/src/dev/_2lstudios/viarewindpotions/utils/PotionTranslator.java
@@ -18,7 +18,8 @@ public enum PotionTranslator {
 	REGENERATION(PotionEffectType.REGENERATION, new TranslationData(16385, 0, 106)),
 	STRENGTH(PotionEffectType.INCREASE_DAMAGE, new TranslationData(16393, 0, 106)),
 	WEAKNESS(PotionEffectType.WEAKNESS, new TranslationData(16424, 0, 106)),
-	LUCK(PotionEffectType.LUCK, new TranslationData(16388, 0, 106));
+	LUCK(PotionEffectType.LUCK, new TranslationData(16388, 0, 106)),
+	SLOW_FALLING(PotionEffectType.SLOW_FALLING, new TranslationData(16427, 0, 106));
 
 	private PotionEffectType effect;
 	private TranslationData[] datas;

--- a/src/dev/_2lstudios/viarewindpotions/utils/PotionTranslator.java
+++ b/src/dev/_2lstudios/viarewindpotions/utils/PotionTranslator.java
@@ -19,7 +19,7 @@ public enum PotionTranslator {
 	STRENGTH(PotionEffectType.INCREASE_DAMAGE, new TranslationData(16393, 0, 106)),
 	WEAKNESS(PotionEffectType.WEAKNESS, new TranslationData(16424, 0, 106)),
 	LUCK(PotionEffectType.LUCK, new TranslationData(16388, 0, 106)),
-	SLOW_FALLING(PotionEffectType.SLOW_FALLING, new TranslationData(16427, 0, 106));
+	SLOW_FALLING(PotionEffectType.SLOW_FALLING, new TranslationData(16394, 0, 106));
 
 	private PotionEffectType effect;
 	private TranslationData[] datas;


### PR DESCRIPTION
- Added missing translation for SLOW_FALLING in PotionTranslator.java
- Changed the translation of the missing potion. In the original plugin for some reason it is translated as speed potion (16386), so, I thought more convenient to translate it as Slowness potion (16394).