### PR TITLE
Added check for enabled compatible plugins

### DIFF
--- a/src/dev/_2lstudios/viarewindpotions/Main.java
+++ b/src/dev/_2lstudios/viarewindpotions/Main.java
@@ -3,6 +3,7 @@ package dev._2lstudios.viarewindpotions;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
 
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -19,8 +20,19 @@ public class Main extends JavaPlugin {
 		final PluginManager pluginManager = getServer().getPluginManager();
 		final ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
 
-		if (pluginManager.getPlugin("ViaRewind-Legacy-Support") == null || !configurationUtil.getConfiguration("%datafolder%/ViaRewind-Legacy-Support/config.yml").getBoolean("area-effect-cloud-particles"))
+		if (pluginManager.isPluginEnabled("ProtocolSupport") || pluginManager.isPluginEnabled("ViaRewind")) {
+			getLogger().info("ViaRewind/ProtocolSupport detected, enabling integration.");
+		} else if (pluginManager.isPluginEnabled("ViaBackwards")) {
+			getLogger().warning("ViaBackwards detected. In order to make ViaPotions work correctly, it is required that you have ViaRewind installed.");
+		} else {
+			getLogger().severe("No compatible plugins have been detected, disabling the plugin.");
+			getLogger().severe("In order to make ViaPotions functional, ViaRewind or ProtocolSupport must be installed.");
+			pluginManager.disablePlugin(this);
+		}
+		
+		if (pluginManager.getPlugin("ViaRewind-Legacy-Support") == null || !configurationUtil.getConfiguration("%datafolder%/ViaRewind-Legacy-Support/config.yml").getBoolean("area-effect-cloud-particles")) {
 			pluginManager.registerEvents(new AreaEffectCloudListener(this, versionUtil), this);
+		}
 
 		protocolManager.addPacketListener(new SpawnEntityListener(this, versionUtil));
 		protocolManager.addPacketListener(new WorldEventAdapter(this, versionUtil));


### PR DESCRIPTION
- Added check for compatible plugins that are enabled, to prevent the plugin from being enabled in cases where neither ViaRewind nor ProtocolSupport are found. _To avoid reports about the plugin not working and to give an informative message about the problem._