### PR TITLE
Small changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,23 +4,16 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
-    # ViaPotions requires Java 16 to compile. 
-    # However, it works in Java 8 up to Java 16.
-    strategy:
-      matrix:
-        java: [16]
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
     
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 16
       uses: actions/setup-java@v2
       with:
-        java-version: ${{ matrix.java }}
+        java-version: 16
         distribution: 'adopt'
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,9 +18,4 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-      
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2.2.3
-      with:
-        name: ViaPotions
-        path: target/ViaPotions.jar
+

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,13 @@
     <dependency>
       <groupId>com.viaversion</groupId>
       <artifactId>viaversion-api</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib</artifactId>
-      <version>4.6.0</version>
+      <version>4.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.16.5-R0.1-SNAPSHOT</version>
+      <version>1.17.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/dev/_2lstudios/viapotions/adapters/WorldEventAdapter.java
+++ b/src/dev/_2lstudios/viapotions/adapters/WorldEventAdapter.java
@@ -24,10 +24,6 @@ public class WorldEventAdapter extends PacketAdapter {
 	}
 
 	@Override
-	public void onPacketReceiving(PacketEvent event) {
-	}
-
-	@Override
 	public void onPacketSending(PacketEvent event) {
 		final PacketContainer packet = event.getPacket();
 		final int effectId = packet.getIntegers().read(0);

--- a/src/dev/_2lstudios/viapotions/utils/ConfigurationUtil.java
+++ b/src/dev/_2lstudios/viapotions/utils/ConfigurationUtil.java
@@ -22,5 +22,4 @@ public class ConfigurationUtil {
 			return new YamlConfiguration();
 		}
 	}
-
 }

--- a/src/dev/_2lstudios/viapotions/utils/PotionTranslator.java
+++ b/src/dev/_2lstudios/viapotions/utils/PotionTranslator.java
@@ -36,5 +36,4 @@ public enum PotionTranslator {
 	public TranslationData[] getDatas() {
 		return datas;
 	}
-
 }

--- a/src/dev/_2lstudios/viapotions/utils/SplashTranslator.java
+++ b/src/dev/_2lstudios/viapotions/utils/SplashTranslator.java
@@ -33,5 +33,4 @@ public enum SplashTranslator {
 	public TranslationData[] getDatas() {
 		return datas;
 	}
-
 }

--- a/src/dev/_2lstudios/viapotions/utils/TranslationData.java
+++ b/src/dev/_2lstudios/viapotions/utils/TranslationData.java
@@ -20,5 +20,4 @@ public class TranslationData {
 	public int getHighestVersion() {
 		return highestVersion;
 	}
-
 }

--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -6,4 +6,4 @@ api-version: 1.13
 softdepend:
   - "ViaRewind"
   - "ViaRewind-Legacy-Support"
-main: dev._2lstudios.viarewindpotions.Main
+main: dev._2lstudios.viapotions.ViaPotions


### PR DESCRIPTION
- Updated ProtocolLib from 4.6.0 to 4.7.0 and ViaVersion-API from 4.0.0 to 4.0.1.
- Fixed error when starting the plugin on the server due to recent changes. (plugin.yml)
- Since the use of the ProtocolSupport API has been removed, JDK 16 is no longer required to compile the plugin. Therefore, remove the corresponding message and clean up the file (maven.yml).